### PR TITLE
fix: improper handling of utf8-encoded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+file.json

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ async function run() {
     const apiSettingId = core.getInput('readme-api-id', { required: true });
     const apiVersion = core.getInput('readme-api-version', { required: true });
     const token = core.getInput('repo-token', { required: true });
-  
+
     const client = new github.GitHub(token);
 
     const apiFile = await client.repos.getContents({
@@ -21,7 +21,7 @@ async function run() {
       ref: github.context.ref,
     });
 
-    fs.writeFileSync('file.json', new Buffer(apiFile.data.content, 'base64').toString('ascii'));
+    fs.writeFileSync('file.json', Buffer.from(apiFile.data.content, 'base64').toString('utf8'));
 
     const options = {
       formData: {
@@ -44,7 +44,7 @@ async function run() {
         core.setFailed(err.message);
       }
     });
-  
+
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
This resolves a bug in our JSON handling where files with UTF8 characters (like a smart quote) weren't being encoded properly, resulting in invalid JSON.

Additionally, I've:

* Moved the Buffer instantiation from `new Buffer` to `Buffer.from` because Buffer constructor has been deprecated: https://nodejs.org/gl/docs/guides/buffer-constructor-deprecation/