### PR TITLE
docs: use actions/checkout@v2 instead of @master

### DIFF
--- a/demo/.github/workflows/readme-api-sync.yml
+++ b/demo/.github/workflows/readme-api-sync.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: readmeio/github-readme-sync@2.0.0
         with:
           readme-oas-key: ${{ secrets.README_OAS_KEY }}


### PR DESCRIPTION
Not sure what other files need to change since we're tracking all of `node_modules`?