### PR TITLE
fix: don't validate OpenAPI/Swagger file via oas-normalize

### DIFF
--- a/main.js
+++ b/main.js
@@ -157,7 +157,7 @@ async function run() {
       });
     })
     .catch(err => {
-      setFailed(`There was an error finding or loading your OpenAPI/Swagger file.\n\n${err.message || err}`);
+      setFailed(`There was an error finding or loading your OpenAPI/Swagger file.\n\n${err && err.message}`);
     });
 }
 

--- a/main.js
+++ b/main.js
@@ -78,18 +78,8 @@ async function run() {
   })
     .then(async generatedSwaggerString => {
       const oas = new OAS(generatedSwaggerString);
-      const validate = promisify(oas.validate);
-      try {
-        await validate.call(oas);
-      } catch (e) {
-        debug(`Error validating spec: ${e}`);
-        const innerMessage = e.errors && e.errors[0] && e.errors[0].message;
-        const outerMessage = e.name ? `${e.name}: ${e.message}` : e.message;
-        throw setFailed(`There was an error validating your OAS file.\n\n${innerMessage || outerMessage || e}`);
-      }
-      debug('OpenAPI/Swagger file validated!');
-
       oas.bundle(function (err, schema) {
+        if (err) return setFailed(`Error bundling your file: ${err.message}`);
         schema['x-github-repo'] = process.env.GITHUB_REPOSITORY;
         debug(`\`x-github-repo\`: ${schema['x-github-repo']}`);
         schema['x-github-sha'] = process.env.GITHUB_SHA;


### PR DESCRIPTION
We were seeing inconsistencies with the validation via [`oas-normalize`](https://www.npmjs.com/package/oas-normalize), so this removes that validation entirely.

Per discussion with @erunion and @domharrington, the ReadMe API has a better, more well-maintained OpenAPI/Swagger file validator and removing the validator from here will leave us with one less pain point to maintain.

~One outstanding question: do we get rid of `oas.bundle()` from this package entirely? I'm not exactly sure what purpose it's serving.~ **EDIT:** Answered: https://github.com/readmeio/github-readme-sync/pull/41#issuecomment-716871381