### PR TITLE
fix: clearer error message for incorrect readme-oas-key

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,11 @@ async function run() {
     );
   }
 
+  if (!readmeKey || !apiSettingId)
+    return core.setFailed(
+      'Invalid input in `readme-oas-key`. Check out our docs for information on this value: https://docs.readme.com/docs/automatically-sync-api-specification-with-github'
+    );
+
   function sanitizeKeys(input) {
     let sanitizedInput = input;
 

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ async function run() {
     readmeKey = oasKey.split(':')[0];
     apiSettingId = oasKey.split(':')[1];
   } catch (e) {
-    core.setFailed(
+    return core.setFailed(
       'You need to set your key in secrets!\n\nIn the repo, go to Settings > Secrets and add README_OAS_KEY. You can get the value from your ReadMe account.'
     );
   }
@@ -81,7 +81,7 @@ async function run() {
     core.info(`OpenAPI/Swagger file found: ${baseFile}`);
   }
 
-  swaggerInline('**/*', {
+  return swaggerInline('**/*', {
     format: '.json',
     metadata: true,
     base: baseFile,

--- a/main.js
+++ b/main.js
@@ -28,13 +28,19 @@ async function run() {
   }
 
   function sanitizeKeys(input) {
-    // Sanitize ReadMe API Key
-    const keySanitized = sanitize(readmeKey);
-    let sanitizedInput = input.replace(new RegExp(readmeKey, 'g'), keySanitized);
+    let sanitizedInput = input;
 
-    // Sanitize Spec ID
-    const specIdSanitized = sanitize(apiSettingId);
-    sanitizedInput = sanitizedInput.replace(new RegExp(apiSettingId, 'g'), specIdSanitized);
+    try {
+      // Sanitize ReadMe API Key
+      const keySanitized = sanitize(readmeKey);
+      sanitizedInput = input.replace(new RegExp(readmeKey, 'g'), keySanitized);
+
+      // Sanitize Spec ID
+      const specIdSanitized = sanitize(apiSettingId);
+      sanitizedInput = sanitizedInput.replace(new RegExp(apiSettingId, 'g'), specIdSanitized);
+    } catch (e) {
+      core.debug(`Error while sanitizing input: ${e}`);
+    }
 
     return sanitizedInput;
   }


### PR DESCRIPTION
This does a couple things to make our errors a little clearer when the `readme-oas-key` is improperly formatted:
- [x] fix: add try/catch around sanitization - 25ccfef
- [x] fix: add better error message for incorrect readme-oas-key inputs - da3b50a

closes #40