### PR TITLE
Add working-dir input parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,8 @@ inputs:
   readme-oas-key:
     description: 'Your ReadMe key, which we give you when setting up GitHub Sync in ReadMe!'
 
+  working-dir:
+    description: 'The given directory as working directory.'
   oas-file-path:
     description: 'The relative path for your API spec file (Default: We try to guess!)'
   api-version:

--- a/demo/.github/workflows/readme-api-sync.yml
+++ b/demo/.github/workflows/readme-api-sync.yml
@@ -15,6 +15,7 @@ jobs:
           # [OPTIONAL CONFIG]
           # These are optional, don't use unless you need to!
 
+          # working-dir: '.'
           # oas-file-path: './swagger.json'
           # api-version: 'v1.0.0'
 

--- a/main.js
+++ b/main.js
@@ -63,10 +63,16 @@ async function run() {
   debug(`readmeKey (split from \`readme-oas-key\`): ${readmeKey}`);
   debug(`apiSettingId (split from \`readme-oas-key\`): ${apiSettingId}`);
 
+  const workingDir = core.getInput('working-dir');
+  debug(`workingDir (from \`working-dir\` input): ${workingDir}`);
   const apiVersion = core.getInput('api-version');
   debug(`apiVersion (from \`api-version\` input): ${apiVersion}`);
   const apiFilePath = core.getInput('oas-file-path');
   debug(`apiFilePath (from \`oas-file-path\` input): ${apiFilePath}`);
+
+  if (workingDir) {
+    process.chdir(workingDir)
+  }
 
   let baseFile = apiFilePath;
 


### PR DESCRIPTION
We use a monorepo structure to manage our projects and our OpenAPI specification contains relative references to external models.

So when running this action, we need to specify the current working directory to handle those relative paths.

This PR adds an optional `working-dir` parameter to this action.